### PR TITLE
propellers msgs with fc for target speed

### DIFF
--- a/flight_controller.c
+++ b/flight_controller.c
@@ -15,6 +15,8 @@ typedef union
 	uint16_t type;
 	struct _pulse pulse;
 	char rmsg[MAX_STRING_LEN];
+	get_target_speed_msg_t msg_target;
+	get_target_speed_resp_t resp_target;
 } recv_buf_t;
 
 
@@ -58,6 +60,7 @@ int main(int argc, char* argv[])
 	int rcvid;
 	char reply_msg[MAX_STRING_LEN];
 	recv_buf_t msg;
+	get_target_speed_resp_t resp_target;
 	void *ptr;
 
 	// register server name
@@ -111,12 +114,19 @@ int main(int argc, char* argv[])
 
 		// got a message
 		else {
-			printf("[FC] Received message: %s\n", msg.rmsg);
-			strcpy(reply_msg, "reply from server");
-			MsgReply(rcvid, EOK, &reply_msg, sizeof(reply_msg));
+//			printf("[FC] Received message type: %d\n", msg.type);
+
+			switch (msg.type)
+			{
+			case GET_TARGET_SPEED_MSG_TYPE:
+				// TODO target speed should come from the NAVIGATION PROCESS. Using HOVER for now debug purposes.
+				resp_target.target = HOVER;
+				MsgReply(rcvid, EOK, &resp_target, sizeof(resp_target));
+				break;
+			}
 		}
 
-		// reset buffers
+		// reset buffers (only when using string msgs, currently unused).
 		memset(reply_msg, 0, sizeof(reply_msg));
 		memset(msg.rmsg, 0, sizeof(msg.rmsg));
 	}

--- a/flight_controller.h
+++ b/flight_controller.h
@@ -1,10 +1,21 @@
 #ifndef FLIGHT_CONTROLLER_H_
 #define FLIGHT_CONTROLLER_H_
 
+#include <stdint.h>
+#include <sys/iomsg.h>
+#include <sys/mman.h>
+
 #define SERVER_NAME "flight_controller"
 #define MAX_STRING_LEN 128
 #define SHM_NAME "data"
 #define PAGE_SIZE 4096
+
+// SPEED (RPM) Values
+#define STOP	0
+#define DESCEND	2500
+#define HOVER	5000
+#define ASCEND	7500
+#define MAX_RPM	10000
 
 
 // PULSE CODES
@@ -14,5 +25,15 @@
 #define _PULSE_CODE_UPDATE_SPEED4 (_PULSE_CODE_MINAVAIL + 4)
 
 // MESSAGE CODES
+#define GET_TARGET_SPEED_MSG_TYPE	(_IO_MAX + 1)
+
+
+typedef struct get_target_speed_msg {
+	uint16_t type;
+} get_target_speed_msg_t;
+
+typedef struct get_target_speed_resp {
+	unsigned target;
+} get_target_speed_resp_t;
 
 #endif /* FLIGHT_CONTROLLER_H_ */

--- a/propeller.h
+++ b/propeller.h
@@ -5,4 +5,9 @@
 
 const char *shmem_props[] = {"prop1", "prop2", "prop3", "prop4"};
 
+struct thread_args {
+	void *ptr;
+	int coid;
+};
+
 #endif /* PROPELLER_H_ */

--- a/sensor.c
+++ b/sensor.c
@@ -18,11 +18,6 @@ void *sens2(void *);
 void *sens3(void *);
 void *sens4(void *);
 
-struct thread_args {
-	void *ptr;
-	int coid;
-};
-
 
 
 int main(void) {
@@ -63,10 +58,10 @@ int main(void) {
 		pthread_attr_t attr;
 		pthread_attr_init(&attr);
 		pthread_attr_setschedpolicy(&attr, SCHED_RR);
-		pthread_create(NULL, NULL, funcs[i], (void *)args);
+		pthread_create(NULL, &attr, funcs[i], (void *)args);
 	}
 
-	sleep(5);
+	sleep(10); 	// TODO (maybe pthread join to wait for them instead)
 	return 0;
 }
 


### PR DESCRIPTION
Propellers send msgs to Flight Controller to get the target speeds.
Server replies with the target speed and propellers set it.
This will be useful for when we introduce wind. For example, if currSpeed < target then we adjust speed such that currSpeed = target.
So if wind slows down the propellers, then we have logic to force the speed back up to match target.